### PR TITLE
fix(GoldbergTarjanPushRelabelAlgorithm): debug check on s/t node click

### DIFF
--- a/implementation/maxflow-push-relabel/js/GoldbergTarjanPushRelabelAlgorithm.js
+++ b/implementation/maxflow-push-relabel/js/GoldbergTarjanPushRelabelAlgorithm.js
@@ -125,7 +125,7 @@ function GoldbergTarjanPushRelabelAlgorithm(svgSelection,svgSelection2) {
      * attach onClick listeners so we can select start/target node
      * @override
      */
-    if(!isDebug){
+    if(!isDebug()){
     this.onNodesEntered = function(selection) {
         //select source and target nodes
         selection


### PR DESCRIPTION
the source/target selection was broken due to a invalid check of the `isDebug` method, the if was checking the reference and not the returned value